### PR TITLE
Add reflection hints for field access

### DIFF
--- a/src/main/java/com/example/demo/ReflectionController.java
+++ b/src/main/java/com/example/demo/ReflectionController.java
@@ -1,12 +1,17 @@
 package com.example.demo;
 
-import org.springframework.aot.hint.annotation.Reflective;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import com.example.demo.ReflectionController.ReflectionControllerHints;
+
 @RestController
+@ImportRuntimeHints(ReflectionControllerHints.class)
 public class ReflectionController {
 
     @GetMapping("/reflection")
@@ -14,7 +19,6 @@ public class ReflectionController {
         return getMessage();
     }
 
-    @Reflective
     private String getMessage() {
         try {
             String className = Arrays.asList("com", "example", "demo", "Message").stream().collect(Collectors.joining("."));
@@ -23,4 +27,13 @@ public class ReflectionController {
             return "Got an error: " + e.getMessage();
         }
     }
+
+    static class ReflectionControllerHints implements RuntimeHintsRegistrar {
+
+        @Override
+        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+            hints.reflection().registerType(Message.class, type -> type.withField("MESSAGE"));
+        }
+    }
+
 }


### PR DESCRIPTION
This provides the necessary to call `Message.MESSAGE` via reflection. 

`Reflective` is meant to flag the annotated method as being invoked by reflection on any bean. You can see a usage of this annotation in [`@EventListener`](https://github.com/spring-projects/spring-framework/blob/0b5800ae39f4d6e1731c0ca57c2bef6bc960f8a8/spring-context/src/main/java/org/springframework/context/event/EventListener.java#L93). By adding `@EventListener` on a bean, Spring AOT automatically registers the necessary reflection hints so that the framework can call this method using reflection.

For more fine grained access, `RuntimeHints` is an API on top of GraalVM's hint format. The lower-level is `RuntimeHintsRegistrar` that this PR uses as there's no real declarative way to see that `MESSAGE` is called via reflection.

Hints are gathered where they are used. In this case, if the controller is not contributed to the application, the hint isn't contributed either. This makes hints registration more modular and flexible.