### PR TITLE
Use ReflectiveScan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0-M1</version>
+		<version>3.4.0-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -52,6 +52,14 @@
 	</build>
 	<repositories>
 		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
 			<url>https://repo.spring.io/milestone</url>
@@ -61,6 +69,14 @@
 		</repository>
 	</repositories>
 	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -2,8 +2,10 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ReflectiveScan;
 
 @SpringBootApplication
+@ReflectiveScan
 public class DemoApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/demo/Message.java
+++ b/src/main/java/com/example/demo/Message.java
@@ -1,6 +1,9 @@
 package com.example.demo;
 
+import org.springframework.aot.hint.annotation.Reflective;
+
 public class Message {
-    
+
+	@Reflective
     public static final String MESSAGE = "Hello from Spring Native!🤖";
 }

--- a/src/main/java/com/example/demo/ReflectionController.java
+++ b/src/main/java/com/example/demo/ReflectionController.java
@@ -1,6 +1,5 @@
 package com.example.demo;
 
-import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.Arrays;
@@ -14,7 +13,6 @@ public class ReflectionController {
         return getMessage();
     }
 
-    @RegisterReflectionForBinding(Message.class)
     private String getMessage() {
         try {
             String className = Arrays.asList("com", "example", "demo", "Message").stream()


### PR DESCRIPTION
This commit uses a new feature in Spring Framework 6.2 that allows to scan arbitrary types for reflective information. Previously, only Spring beans were considered.

This is using the snapshot for now but it should land in Spring Boot 3.4.0-M1 end of next week.

See also https://docs.spring.io/spring-framework/reference/6.2-SNAPSHOT/core/aot.html#aot.hints.reflective